### PR TITLE
Fix image placeholder type for Next.js Image component

### DIFF
--- a/utils/images.ts
+++ b/utils/images.ts
@@ -28,26 +28,34 @@ export function getImageProps(
   const dimensions = customDimensions || defaultDimensions[type];
   
   // Check if src is a StaticImageData (imported image)
-  const isStaticImage = typeof src !== 'string';
+  const isStaticImage = typeof src === 'object';
 
-  return {
+  const imageProps = {
     src,
     ...dimensions,
     alt: '', // This will be overridden when used
-    className: 'object-cover',
-    ...(isStaticImage ? { placeholder: 'blur' as const } : {
-      blurDataURL: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkMjU1LC0yMi4xODY6Oj03MS85RUVFOz5KSlNTWFFCRVBXUFNLU0r/2wBDAR',
-      placeholder: 'blur' as const
-    })
+    className: 'object-cover w-full h-full',
   };
+
+  // Only add placeholder properties for non-static images
+  if (!isStaticImage) {
+    return {
+      ...imageProps,
+      blurDataURL: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkMjU1LC0yMi4xODY6Oj03MS85RUVFOz5KSlNTWFFCRVBXUFNLU0r/2wBDAR',
+      placeholder: 'blur' as const,
+    };
+  }
+
+  return imageProps;
 }
 
 export function getPlaceholderImage(type: keyof typeof defaultDimensions = 'product') {
+  const dimensions = defaultDimensions[type];
   return {
     src: '/images/placeholder.jpg',
-    ...defaultDimensions[type],
+    ...dimensions,
     alt: 'Placeholder image',
-    className: 'object-cover bg-brown-100',
+    className: 'object-cover bg-brown-100 w-full h-full',
   };
 }
 


### PR DESCRIPTION
This PR fixes the TypeScript error with the Next.js Image component placeholder prop by:

1. Properly handling static vs external images
2. Only adding placeholder and blurDataURL for external images
3. Adding proper type assertions for the placeholder prop
4. Improving image class names for better responsive behavior

Changes:
- Updated `getImageProps` function to properly handle StaticImageData
- Added proper type checking for image sources
- Improved className handling for responsive images
- Fixed TypeScript types for placeholder prop